### PR TITLE
Storing linkedDataPoints as GUIDs to avoid circular reference.

### DIFF
--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -47,3 +47,19 @@ export const GetDataPoints = () => {
 
   return DataPoints ? DataPoints : undefined;
 };
+
+export const GetDataPointFromGUID = (guid: string) => {
+  const dataPoints = GetDataPoints();
+
+  if (!dataPoints) {
+    throw Error('No DataPoints in the global state.');
+  }
+
+  for (let point of dataPoints) {
+    if (point.id === guid) {
+      return point;
+    }
+  }
+
+  throw Error('GUID must exist on a DataPoint');
+};

--- a/src/Data/DataPoint.ts
+++ b/src/Data/DataPoint.ts
@@ -1,9 +1,11 @@
+import { GetDataPointFromGUID } from '../Data/Data';
+
 export class DataPoint {
   lineNumber: string = '';
   detail: string = '';
   id: string = '';
   file: string = '';
-  linkedDataPoints: DataPoint[] = [];
+  linkedDataPoints: string[] = [];
 
   //This is static as we work with DataPoints returned from vscode global storage which doesn't
   //include functions on an instance of a class.
@@ -16,18 +18,20 @@ export class DataPoint {
 			Line Number: ${dataPoint.lineNumber}	
 			Detail: ${dataPoint.detail}	
 			Linked Data Points =>
-				${renderLinkedDataPoints(dataPoint.linkedDataPoints)}
+				${renderLinkedDataPointsAsText(dataPoint.linkedDataPoints)}
 			|=======================================|
 			
 			`;
   };
 }
 
-const renderLinkedDataPoints = (linkedDataPoints: DataPoint[]) => {
+const renderLinkedDataPointsAsText = (linkedDataPoints: string[]) => {
   if (linkedDataPoints.length > 0) {
     let string = '';
 
-    linkedDataPoints.forEach(point => {
+    linkedDataPoints.forEach(pointGUID => {
+      const point = GetDataPointFromGUID(pointGUID);
+
       string += `${point.id} | ${point.file}:${point.lineNumber} \n`;
     });
 

--- a/src/Input/Input.ts
+++ b/src/Input/Input.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { PushDataPoint } from '../Data/Data';
+import { PushDataPoint, GetDataPointFromGUID } from '../Data/Data';
 import { DataPoint } from '../Data/DataPoint';
 
 import { getLineNumberFromUser } from './UserInput/getLineNumberFromUser';
@@ -23,7 +23,7 @@ export async function CreateDataPoint() {
   let linkedDataPoint = await getLinkedDataPointFromUser();
 
   if (linkedDataPoint !== undefined) {
-    dataPoint.linkedDataPoints.push(linkedDataPoint);
+    dataPoint.linkedDataPoints.push(linkedDataPoint.id);
   }
 
   dataPoint.file = await getActiveFile();
@@ -40,13 +40,17 @@ export async function AddAdditionalLinkToDataPoint() {
   let currentDataPoint = await getDataPointFromUser();
 
   if (currentDataPoint !== undefined) {
+    let linkedDataPoints: DataPoint[] = currentDataPoint.linkedDataPoints.map(dataPointGuid => {
+      return GetDataPointFromGUID(dataPointGuid);
+    });
+
     let newLinkedDataPoint = await getLinkedDataPointFromUser([
       currentDataPoint,
-      ...currentDataPoint.linkedDataPoints
+      ...linkedDataPoints
     ]);
 
     if (newLinkedDataPoint) {
-      currentDataPoint.linkedDataPoints.push(newLinkedDataPoint);
+      currentDataPoint.linkedDataPoints.push(newLinkedDataPoint.id);
     }
 
     PushDataPoint(currentDataPoint);

--- a/src/Output/Output.ts
+++ b/src/Output/Output.ts
@@ -55,7 +55,7 @@ export const GenerateDiagram = () => {
   datapoint2.file = 'javascript/testfile2.js';
   datapoint2.lineNumber = '98';
   datapoint2.detail = 'This is another test';
-  datapoint2.linkedDataPoints = [datapoint1];
+  datapoint2.linkedDataPoints = [datapoint1.id];
 
   dataPoints.push(datapoint1);
   dataPoints.push(datapoint2);


### PR DESCRIPTION
Was previously storing the linked data points as an array of DataPoint objects on the DataPoint object itself which would have resulted in an infinitely expanding array of arrays etc etc.

Now storing the linked data points as their GUIDs and then have a util function to just grab an entire Data Point object from that GUID.