### PR TITLE
Feature/choosing link direction

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,18 +1,18 @@
-const scssSrcDirectory = './src/Output/external/diagram.scss';
-const htmlSrcDirectory = './src/Output/external/diagram.html';
+const scssSrcDirectory = './src/Output/Diagram/diagram.scss';
+const htmlSrcDirectory = './src/Output/Diagram/diagram.html';
 
 module.exports = function(grunt) {
   grunt.initConfig({
     sass: {
       dev: {
         files: {
-          './out/Output/diagram.css': scssSrcDirectory
+          './out/Output/Diagram/diagram.css': scssSrcDirectory
         }
       }
     },
     copy: {
       main: {
-        files: [{ nonull: true, src: htmlSrcDirectory, dest: './out/Output/diagram.html' }]
+        files: [{ nonull: true, src: htmlSrcDirectory, dest: './out/Output/Diagram/diagram.html' }]
       }
     },
     watch: {

--- a/src/Input/AddAdditionalLinkToDataPoint.ts
+++ b/src/Input/AddAdditionalLinkToDataPoint.ts
@@ -10,17 +10,19 @@ import { GetDataPointFromUser, GetLinkedDataPointFromUser } from './UserInput/Ge
  * it on the global state.
  */
 export async function AddAdditionalLinkToDataPoint() {
-  let currentDataPoint = await GetDataPointFromUser();
+  let currentDataPoint = await GetDataPointFromUser(
+    'Choose a Data Point to add an additional link to'
+  );
 
   if (currentDataPoint !== undefined) {
     let linkedDataPoints: DataPoint[] = currentDataPoint.linkedDataPoints.map(dataPointGuid => {
       return GetDataPointFromGUID(dataPointGuid);
     });
 
-    let newLinkedDataPoint = await GetLinkedDataPointFromUser([
-      currentDataPoint,
-      ...linkedDataPoints
-    ]);
+    let newLinkedDataPoint = await GetLinkedDataPointFromUser(
+      'Which data point should it link to?',
+      [currentDataPoint, ...linkedDataPoints]
+    );
 
     if (newLinkedDataPoint) {
       currentDataPoint.linkedDataPoints.push(newLinkedDataPoint.id);

--- a/src/Input/CreateDataPoint.ts
+++ b/src/Input/CreateDataPoint.ts
@@ -24,14 +24,16 @@ export async function CreateDataPoint() {
   const linkDirection = await GetLinkDirectionFromUser();
 
   if (linkDirection !== LinkDirection.NoLink) {
-    const linkedDataPoint = await GetLinkedDataPointFromUser('Choose a Data Point to link with');
-
-    if (linkedDataPoint) {
-      if (linkDirection === LinkDirection.To) {
-        dataPoint.linkedDataPoints.push(linkedDataPoint.id);
-      } else if (linkDirection === LinkDirection.From) {
-        linkedDataPoint.linkedDataPoints.push(dataPoint.id);
-        PushDataPoint(linkedDataPoint);
+    const point = await getLinkedDataPointFromUser();
+    if (point) {
+      switch (linkDirection) {
+        case LinkDirection.To:
+          point.linkedDataPoints.push(linkedDataPoint.id);
+          break;
+        case LinkDirection.From:
+          point.linkedDataPoints.push(dataPoint.id);
+          pushDataPoint(point);
+          break;
       }
     }
   }

--- a/src/Input/CreateDataPoint.ts
+++ b/src/Input/CreateDataPoint.ts
@@ -24,15 +24,15 @@ export async function CreateDataPoint() {
   const linkDirection = await GetLinkDirectionFromUser();
 
   if (linkDirection !== LinkDirection.NoLink) {
-    const point = await getLinkedDataPointFromUser();
+    const point = await GetLinkedDataPointFromUser('Choose a Data Point to link with');
     if (point) {
       switch (linkDirection) {
         case LinkDirection.To:
-          point.linkedDataPoints.push(linkedDataPoint.id);
+          point.linkedDataPoints.push(point.id);
           break;
         case LinkDirection.From:
           point.linkedDataPoints.push(dataPoint.id);
-          pushDataPoint(point);
+          PushDataPoint(point);
           break;
       }
     }

--- a/src/Input/CreateDataPoint.ts
+++ b/src/Input/CreateDataPoint.ts
@@ -5,6 +5,7 @@ import { DataPoint } from '../Data/DataPoint';
 
 import { GetLineNumberFromUser } from './UserInput/GetLineNumberFromUser';
 import { GetDetailFromUser } from './UserInput/GetDetailFromUser';
+import { GetLinkDirectionFromUser, LinkDirection } from './UserInput/GetLinkDirectionFromUser';
 import { GetLinkedDataPointFromUser } from './UserInput/GetDataPointFromUser';
 
 import { generateDataPointId } from '../Utils/generateDataPointId';
@@ -20,14 +21,24 @@ export async function CreateDataPoint() {
   dataPoint.detail = await GetDetailFromUser();
   dataPoint.id = await generateDataPointId();
 
-  let linkedDataPoint = await GetLinkedDataPointFromUser();
+  const linkDirection = await GetLinkDirectionFromUser();
 
-  if (linkedDataPoint !== undefined) {
-    dataPoint.linkedDataPoints.push(linkedDataPoint.id);
+  if (linkDirection !== LinkDirection.NoLink) {
+    const linkedDataPoint = await GetLinkedDataPointFromUser('Choose a Data Point to link with');
+
+    if (linkedDataPoint) {
+      if (linkDirection === LinkDirection.To) {
+        dataPoint.linkedDataPoints.push(linkedDataPoint.id);
+      } else if (linkDirection === LinkDirection.From) {
+        linkedDataPoint.linkedDataPoints.push(dataPoint.id);
+        PushDataPoint(linkedDataPoint);
+      }
+    }
   }
 
   dataPoint.file = await getActiveFile();
 
   PushDataPoint(dataPoint);
+
   vscode.window.showInformationMessage('Added data point with ID: ' + dataPoint.id);
 }

--- a/src/Input/UserInput/GetLinkDirectionFromUser.ts
+++ b/src/Input/UserInput/GetLinkDirectionFromUser.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+
+export const enum LinkDirection {
+  NoLink = 'No Link',
+  To = 'Link to another Data Point',
+  From = 'Be linked to by another Data Point'
+}
+
+/**
+ * Let the user choose a link direction
+ *
+ * @return Returns a LinkDirection enum
+ */
+export const GetLinkDirectionFromUser = async () => {
+  const chosenDirection = await vscode.window.showQuickPick(
+    [LinkDirection.NoLink, LinkDirection.To, LinkDirection.From],
+    {
+      placeHolder: 'Choose Link Direction'
+    }
+  );
+
+  if (!chosenDirection) {
+    throw Error('User exited the quick pick');
+  }
+
+  if (chosenDirection === LinkDirection.NoLink) {
+    return LinkDirection.NoLink;
+  }
+
+  return chosenDirection === LinkDirection.To ? LinkDirection.To : LinkDirection.From;
+};

--- a/src/Input/UserInput/GetLinkDirectionFromUser.ts
+++ b/src/Input/UserInput/GetLinkDirectionFromUser.ts
@@ -9,7 +9,7 @@ export const enum LinkDirection {
 /**
  * Let the user choose a link direction
  *
- * @return Returns a LinkDirection enum
+ * @return Returns a LinkDirection enum based on the option chosen in the quick pick
  */
 export const GetLinkDirectionFromUser = async () => {
   const chosenDirection = await vscode.window.showQuickPick(

--- a/src/Input/UserInput/getDataPointFromUser.ts
+++ b/src/Input/UserInput/getDataPointFromUser.ts
@@ -65,10 +65,10 @@ const showQuickPicker = async (placeHolder: string, extraSelectableDataPoints?: 
  *
  * @return A Promise that resolves their chosen DataPoint
  */
-export const GetDataPointFromUser = () => {
+export const GetDataPointFromUser = (userInputMessage: string) => {
   return new Promise<DataPoint | undefined>((resolve, reject) => {
     setupDataPoints();
-    showQuickPicker('Choose a Data Point')
+    showQuickPicker(userInputMessage)
       .then(chosenDataPoint => resolve(chosenDataPoint))
       .catch(err => reject(err));
   });
@@ -81,10 +81,13 @@ export const GetDataPointFromUser = () => {
  *
  * @return A Promise that resolves their chosen DataPoint
  */
-export const GetLinkedDataPointFromUser = (pointsToExclude?: DataPoint[]) => {
+export const GetLinkedDataPointFromUser = (
+  userInputMessage: string,
+  pointsToExclude?: DataPoint[]
+) => {
   return new Promise<DataPoint | undefined>((resolve, reject) => {
     setupDataPoints(pointsToExclude);
-    showQuickPicker('Choose another Data Point to link to', ['No Link'])
+    showQuickPicker(userInputMessage, ['No Link'])
       .then(chosenDataPoint => resolve(chosenDataPoint))
       .catch(err => reject(err));
   });


### PR DESCRIPTION
Added the ability to choose a link direction before actually choosing a linked data point.

This is very basic and still leaves a lot to be desired. I will be adding this an issue to tackle later (also on my todo list):

Main problem is that the step for choosing a direction allows you to choose "No Link" which is fine, but the actual choosing of a linked data point also gives you this option whereas it should be fully caught by the direction step where it shouldn't even let you try and choose a data point if you can't.