### PR TITLE
Navigate to the line number as well as the file

### DIFF
--- a/src/Output/WebViewFiles/javascript.js
+++ b/src/Output/WebViewFiles/javascript.js
@@ -6,7 +6,7 @@ export default `
         let node = event && event.target;
         while (node) {
             if (node.tagName && node.tagName === 'A' && node.href) {
-                vscode.postMessage(node.href);
+                vscode.postMessage('{"filePath": "' + node.href + '", "lineNumber": ' + node.dataset.lineNumber + '}');
                 event.preventDefault();
                 return;
             }


### PR DESCRIPTION
Pass the line number in as a data attribute and then grab that in the JS on the webview when a link is clicked and send back an object to vscode containing both the filePath and the line number. We then use the editor.revealRange functionality within vscode to go to the selected line.

This completes #10 